### PR TITLE
pull hammerhead over public url

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.11",
-    "testcafe-hammerhead": "git@github.com:ProdPerfect/testcafe-hammerhead.git",
+    "testcafe-hammerhead": "git://github.com/ProdPerfect/testcafe-hammerhead.git",
     "testcafe-legacy-api": "3.1.11",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",


### PR DESCRIPTION
Need to use the public URL, since our servers aren't set up with ssh keys to pull via ssh.